### PR TITLE
show human-friendly error when credentials are not set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 HOSTNAME=openvpncloud.dev
 NAMESPACE=openvpn
 NAME=openvpncloud
-VERSION=0.0.8
+VERSION=0.0.9
 BINARY=terraform-provider-${NAME}
-OS_ARCH=darwin_amd64
+OS_ARCH=darwin_arm64
 
 default: install
 
@@ -16,6 +16,9 @@ release:
 install: build
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+
+lint:
+	golangci-lint run ./...
 
 test:
 	go test -i $(TEST) || exit 1

--- a/client/client.go
+++ b/client/client.go
@@ -5,10 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/time/rate"
 	"io"
 	"net/http"
 	"time"
+
+	"golang.org/x/time/rate"
 )
 
 type Client struct {
@@ -23,6 +24,10 @@ type Credentials struct {
 }
 
 func NewClient(baseUrl, clientId, clientSecret string) (*Client, error) {
+	if clientId == "" || clientSecret == "" {
+		return nil, ErrCredentialsRequired
+	}
+
 	values := map[string]string{"grant_type": "client_credentials", "scope": "default"}
 	json_data, err := json.Marshal(values)
 	if err != nil {

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,0 +1,5 @@
+package client
+
+import "errors"
+
+var ErrCredentialsRequired = errors.New("both client_id and client_secret credentials must be specified")

--- a/openvpncloud/provider.go
+++ b/openvpncloud/provider.go
@@ -9,6 +9,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+const (
+	clientIDEnvVar     = "OPENVPN_CLOUD_CLIENT_ID"
+	clientSecretEnvVar = "OPENVPN_CLOUD_CLIENT_SECRET"
+)
+
 type Token struct {
 	AccessToken string `json:"access_token"`
 }
@@ -20,13 +25,13 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Sensitive:   true,
-				DefaultFunc: schema.EnvDefaultFunc("OPENVPN_CLOUD_CLIENT_ID", nil),
+				DefaultFunc: schema.EnvDefaultFunc(clientIDEnvVar, nil),
 			},
 			"client_secret": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Sensitive:   true,
-				DefaultFunc: schema.EnvDefaultFunc("OPENVPN_CLOUD_CLIENT_SECRET", nil),
+				DefaultFunc: schema.EnvDefaultFunc(clientSecretEnvVar, nil),
 			},
 			"base_url": {
 				Type:     schema.TypeString,

--- a/openvpncloud/provider_test.go
+++ b/openvpncloud/provider_test.go
@@ -44,10 +44,9 @@ func TestProvider(t *testing.T) {
 	assert.True(t, diags.HasError())
 
 	for _, d := range diags {
-		detail := d.Detail
-		assert.True(t, strings.Contains(detail, client.ErrCredentialsRequired.Error()),
+		assert.True(t, strings.Contains(d.Detail, client.ErrCredentialsRequired.Error()),
 			"error message does not contain the expected error")
-		t.Log(detail)
+		t.Log(d.Detail)
 	}
 }
 

--- a/openvpncloud/resource_user_test.go
+++ b/openvpncloud/resource_user_test.go
@@ -17,10 +17,10 @@ func TestAccOpenvpncloudUser_basic(t *testing.T) {
 		Username:  acctest.RandStringFromCharSet(10, alphabet),
 		FirstName: acctest.RandStringFromCharSet(10, alphabet),
 		LastName:  acctest.RandStringFromCharSet(10, alphabet),
-		Email:     "terraform-tests@devopenvpn.in",
+		Email:     fmt.Sprintf("terraform-tests+%s@devopenvpn.in", acctest.RandString(10)),
 	}
 	userChanged := user
-	userChanged.Email = "terraform-tests+changed@devopenvpn.in"
+	userChanged.Email = fmt.Sprintf("terraform-tests+changed%s@devopenvpn.in", acctest.RandString(10))
 	var userID string
 
 	check := func(user client.User) resource.TestCheckFunc {


### PR DESCRIPTION
`NewClient` will now return a human-friendly error when the credentials are not set.
Fixes #32.

I have also updated the tests related to the user resource.
They used to fail if they were run in parallel. That caused conflict because the same email was used. Now it's fixed.