### PR TITLE
User status fix

### DIFF
--- a/client/user.go
+++ b/client/user.go
@@ -8,17 +8,16 @@ import (
 )
 
 type User struct {
-	Id            string   `json:"id"`
-	Username      string   `json:"username"`
-	Role          string   `json:"role"`
-	Email         string   `json:"email"`
-	AuthType      string   `json:"authType"`
-	FirstName     string   `json:"firstName"`
-	LastName      string   `json:"lastName"`
-	GroupId       string   `json:"groupId"`
-	Status        string   `json:"status"`
-	AccountStatus string   `json:"accountStatus"`
-	Devices       []Device `json:"devices"`
+	Id        string   `json:"id"`
+	Username  string   `json:"username"`
+	Role      string   `json:"role"`
+	Email     string   `json:"email"`
+	AuthType  string   `json:"authType"`
+	FirstName string   `json:"firstName"`
+	LastName  string   `json:"lastName"`
+	GroupId   string   `json:"groupId"`
+	Status    string   `json:"status"`
+	Devices   []Device `json:"devices"`
 }
 
 type Device struct {

--- a/openvpncloud/provider_test.go
+++ b/openvpncloud/provider_test.go
@@ -44,9 +44,8 @@ func TestProvider(t *testing.T) {
 	assert.True(t, diags.HasError())
 
 	for _, d := range diags {
-		assert.True(t, strings.Contains(d.Detail, client.ErrCredentialsRequired.Error()),
-			"error message does not contain the expected error")
-		t.Log(d.Detail)
+		assert.Truef(t, strings.Contains(d.Detail, client.ErrCredentialsRequired.Error()),
+			"error message does not contain the expected error: %s", d.Detail)
 	}
 }
 

--- a/openvpncloud/resource_user.go
+++ b/openvpncloud/resource_user.go
@@ -188,7 +188,7 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, m interface
 	_, firstName := d.GetChange("first_name")
 	_, lastName := d.GetChange("last_name")
 	_, role := d.GetChange("role")
-	status := u.AccountStatus
+	status := u.Status
 	oldGroupId, newGroupId := d.GetChange("group_id")
 
 	groupId := newGroupId.(string)


### PR DESCRIPTION
- User status used to be set via `accountStatus` but the API has changed. Not it will be set via `status`.
- Minor fix for the provider test output. It will not print the errors anymore unless there is an issue.

<img width="524" alt="image" src="https://user-images.githubusercontent.com/7099677/232398529-7cb9b381-b4e5-415c-88a6-7451b3f311eb.png">
