### PR TITLE
Improve resource Service

### DIFF
--- a/client/service.go
+++ b/client/service.go
@@ -11,6 +11,7 @@ import (
 type Range struct {
 	LowerValue int `json:"lowerValue"`
 	UpperValue int `json:"upperValue"`
+	Value      int `json:"value"`
 }
 
 type CustomServiceType struct {

--- a/openvpncloud/resource_service.go
+++ b/openvpncloud/resource_service.go
@@ -2,6 +2,7 @@ package openvpncloud
 
 import (
 	"context"
+
 	"github.com/OpenVPN/terraform-provider-openvpn-cloud/client"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -88,9 +89,31 @@ func resourceServiceConfig() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"protocol": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{"TCP", "UDP", "ICMP"}, false),
+							Description:  "The description for the UI. Defaults to `Managed by Terraform`.",
+						},
+						"port": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"lower_value": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+									"upper_value": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+								},
+							},
+						},
 						"icmp_type": {
 							Type:     schema.TypeList,
-							Required: true,
+							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"lower_value": {
@@ -181,14 +204,16 @@ func flattenCustomServiceTypes(types []*client.CustomServiceType) interface{} {
 		data = append(
 			data,
 			map[string]interface{}{
-				"icmp_type": flattenIcmpType(t.IcmpType),
+				"icmp_type": flattenPorts(t.IcmpType),
+				"port":      flattenPorts(t.Port),
+				"protocol":  t.Protocol,
 			},
 		)
 	}
 	return data
 }
 
-func flattenIcmpType(icmpType []client.Range) interface{} {
+func flattenPorts(icmpType []client.Range) interface{} {
 	var data []interface{}
 	for _, t := range icmpType {
 		data = append(
@@ -249,21 +274,16 @@ func resourceDataToService(data *schema.ResourceData) *client.Service {
 		mainConfig := configList[0].(map[string]interface{})
 		for _, r := range mainConfig["custom_service_types"].([]interface{}) {
 			cst := r.(map[string]interface{})
-			var icmpTypes []client.Range
-			for _, r := range cst["icmp_type"].([]interface{}) {
-				icmpType := r.(map[string]interface{})
-				icmpTypes = append(
-					icmpTypes,
-					client.Range{
-						LowerValue: icmpType["lower_value"].(int),
-						UpperValue: icmpType["upper_value"].(int),
-					},
-				)
-			}
+			icmpTypes := getPortsFromField(cst, "icmp_type")
+			ports := getPortsFromField(cst, "port")
+			protocol := cst["protocol"].(string)
+
 			config.CustomServiceTypes = append(
 				config.CustomServiceTypes,
 				&client.CustomServiceType{
+					Protocol: protocol,
 					IcmpType: icmpTypes,
+					Port:     ports,
 				},
 			)
 		}
@@ -283,4 +303,19 @@ func resourceDataToService(data *schema.ResourceData) *client.Service {
 		Config:          &config,
 	}
 	return s
+}
+
+func getPortsFromField(cst map[string]interface{}, fieldName string) []client.Range {
+	var ranges []client.Range
+	for _, r := range cst[fieldName].([]interface{}) {
+		rangeElem := r.(map[string]interface{})
+		ranges = append(
+			ranges,
+			client.Range{
+				LowerValue: rangeElem["lower_value"].(int),
+				UpperValue: rangeElem["upper_value"].(int),
+			},
+		)
+	}
+	return ranges
 }

--- a/openvpncloud/resource_service.go
+++ b/openvpncloud/resource_service.go
@@ -93,7 +93,6 @@ func resourceServiceConfig() *schema.Resource {
 							Type:         schema.TypeString,
 							Required:     true,
 							ValidateFunc: validation.StringInSlice([]string{"TCP", "UDP", "ICMP"}, false),
-							Description:  "The description for the UI. Defaults to `Managed by Terraform`.",
 						},
 						"port": {
 							Type:     schema.TypeList,
@@ -101,12 +100,22 @@ func resourceServiceConfig() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"lower_value": {
-										Type:     schema.TypeInt,
-										Required: true,
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(0, 65535),
+										Description:  "This argument is designed to be used to define range of ports",
 									},
 									"upper_value": {
-										Type:     schema.TypeInt,
-										Required: true,
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(0, 65535),
+										Description:  "This argument is designed to be used to define range of ports",
+									},
+									"value": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(0, 65535),
+										Description:  "This argument is designed to be used to define singular port",
 									},
 								},
 							},
@@ -117,12 +126,14 @@ func resourceServiceConfig() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"lower_value": {
-										Type:     schema.TypeInt,
-										Required: true,
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(0, 255),
 									},
 									"upper_value": {
-										Type:     schema.TypeInt,
-										Required: true,
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(0, 255),
 									},
 								},
 							},
@@ -314,6 +325,7 @@ func getPortsFromField(cst map[string]interface{}, fieldName string) []client.Ra
 			client.Range{
 				LowerValue: rangeElem["lower_value"].(int),
 				UpperValue: rangeElem["upper_value"].(int),
+				Value:      rangeElem["value"].(int),
 			},
 		)
 	}


### PR DESCRIPTION
Previously it was possible to create only next configuration:

```
resource "openvpncloud_service" "test" {
	name = "test"
	type = "SERVICE_DESTINATION"
	description = "test"
	network_item_type = "NETWORK"
	network_item_id = openvpncloud_network.test.id
	routes = ["test.ua" ]
	config {
		service_types = ["ANY"]
	}
}
```
Which was not enough to configure granularity to take advantage of "Zero trust" CloudConnexa's features.

This PR is intended to improve resource "openvpncloud_service"  (file "resource_service.go").


Disclaimer:
1/ Every time i run "terraform plan" (both before proposed changes and after) - Terraform wants to modify/rewrite "routes"
(i believe it is not related to scope of this PR, just wanted you to know)

```
 # openvpncloud_service.test will be updated in-place
  ~ resource "openvpncloud_service" "test" {
        id                = "6d8998e2-8034-47bc-8da3-9b2c7de403f2"
        name              = "test"
      ~ routes            = [
          - "",
          + "192.168.1.1/32",
        ]
```

2/ Data format looks little bit "bulky" when multiple ports needed to be specified (see examples below)
How it looks like now:
```
custom_service_types {
      protocol = "TCP"
      port {
        lower_value = "53"
        upper_value = "53"
      }
      port {
        lower_value = "88"
        upper_value = "88"
      }
      port {
        lower_value = "389"
        upper_value = "389"
      }
      port {
        lower_value = "464"
        upper_value = "464"
      }
      port {
        lower_value = "636"
        upper_value = "636"
      }
    }
```
(maybe it could be optimized or written more optimal in Terraform, but i don't know how to do it properly)

How it could look better (but i don't know how to do it yet, or even possibly API side should be modified as well, because i've checked with Swagger, and in API side it show that it is stored in format above ^^)

```
custom_service_types {
      protocol = "TCP"
       port {
          lower_value = "53,88,389,464,636"
          upper_value = "53,88,389,464,636"
      }
    }
```
or

```
custom_service_types {
      protocol = "TCP"
       port {
         lower_value = ["53", "88", "389", "464", "636"]
         upper_value = ["53", "88", "389", "464", "636"]
       }
    }
```
(I tried to use both examples above, but got error in Terraform and i believe data structure / scheme should be rewritten for this to work)

